### PR TITLE
Replacement of the word "dirty" in the coin version text to Re

### DIFF
--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -37,7 +37,7 @@ if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" -a -e "$(which git 2>/dev/null)" -a "$(
 
     # otherwise generate suffix from git, i.e. string like "59887e8-dirty"
     SUFFIX=$(git rev-parse --short HEAD)
-    git diff-index --quiet HEAD -- || SUFFIX="$SUFFIX-dirty"
+    git diff-index --quiet HEAD -- || SUFFIX="$SUFFIX-release"
 
     # get a string like "2012-04-10 16:27:19 +0200"
     LAST_COMMIT_DATE="$(git log -n 1 --format="%ci")"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/765487/86495121-b0544e00-bd80-11ea-8d1b-6e3c8b85673c.png)

The Client Version info in the information window has the word "dirty" at the end of it.
This pull request replaces the word "dirty" with "release".