### PR TITLE
fixes to Linux Build script

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
+echo -e "\033[0;32mHow many CPU cores do you want to be used in compiling process? (Default is 1. Press enter for default.)\033[0m"
+read -e CPU_CORES
+if [ -z "$CPU_CORES" ]
+then
+	CPU_CORES=1
+fi
+
 # Upgrade the system and install required dependencies
-	sudo apt update && apt upgrade
+	sudo apt update && sudo apt upgrade
 	sudo apt install git zip unzip build-essential libtool bsdmainutils autotools-dev autoconf pkg-config automake python3 -y
 
 # Clone SAPP code from SAPP official Github repository
@@ -13,15 +20,15 @@
 	cd depends
 	chmod +x config.sub
 	chmod +x config.guess
-	make
+	make -j$(echo $CPU_CORES) HOST=x86_64-pc-linux-gnu 
 	cd ..
 
 # Compile SAPP
 	chmod +x share/genbuild.sh
 	chmod +x autogen.sh
 	./autogen.sh
-	./configure --enable-glibc-back-compat --prefix=$(pwd)/depends/x86_64-pc-linux-gnu LDFLAGS="-static-libstdc++"  --enable-cxx --disable-shared --with-pic CXXFLAGS="-fPIC -O" CPPFLAGS="-fPIC -O"
-	make
+	./configure --enable-glibc-back-compat --prefix=$(pwd)/depends/x86_64-pc-linux-gnu LDFLAGS="-static-libstdc++" --enable-cxx --enable-static --disable-shared --disable-debug --with-pic CPPFLAGS="-fPIC -O3 --param ggc-min-expand=1 --param ggc-min-heapsize=32768"
+	make -j$(echo $CPU_CORES) HOST=x86_64-pc-linux-gnu
 	cd ..
 
 # Create zip file of binaries


### PR DESCRIPTION
Added new parameters to configure.
```
--disable-debug
-O3 --param ggc-min-expand=1 --param ggc-min-heapsize=32768 to CPPFLAGS
```
Removed CXXFLAGS from configure.

Added sudo to "apt upgrade"

Added code for script to ask user about how many CPU cores to be used in the process.

Added "-j$(echo $CPU_CORES) HOST=x86_64-pc-linux-gnu" to make commands for being able to use more than one CPU core and make sure of the building HOST.

