### PR TITLE
Adds CXXFLAGS to get rid of a lot of compilation warnings

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -27,7 +27,7 @@ fi
 	chmod +x share/genbuild.sh
 	chmod +x autogen.sh
 	./autogen.sh
-	./configure --enable-glibc-back-compat --prefix=$(pwd)/depends/x86_64-pc-linux-gnu LDFLAGS="-static-libstdc++" --enable-cxx --enable-static --disable-shared --disable-debug --with-pic CPPFLAGS="-fPIC -O3 --param ggc-min-expand=1 --param ggc-min-heapsize=32768"
+	./configure --enable-glibc-back-compat --prefix=$(pwd)/depends/x86_64-pc-linux-gnu LDFLAGS="-static-libstdc++" --enable-cxx --enable-static --disable-shared --disable-debug --with-pic CPPFLAGS="-fPIC -O3 --param ggc-min-expand=1 --param ggc-min-heapsize=32768" CPPFLAGS="-fPIC -O3 --param ggc-min-expand=1 --param ggc-min-heapsize=32768"
 	make -j$(echo $CPU_CORES) HOST=x86_64-pc-linux-gnu
 	cd ..
 


### PR DESCRIPTION
Adds
```
CPPFLAGS="-fPIC -O3 --param ggc-min-expand=1 --param ggc-min-heapsize=32768"
```
to configure parameters to get rid of a lot of compile warning messages.