### PR TITLE
Fixes compilation errors for boost 1.73/1.74 and deque

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -28,6 +28,7 @@
 #include <event2/buffer.h>
 #include <event2/util.h>
 #include <event2/keyvalq_struct.h>
+#include <deque>
 
 #ifdef EVENT__HAVE_NETINET_IN_H
 #include <netinet/in.h>

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -9,6 +9,9 @@
 
 #include <boost/signals2/signal.hpp>
 #include <boost/shared_ptr.hpp>
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
 
 class CBlock;
 struct CBlockLocator;


### PR DESCRIPTION
Fixes boost 1.73/1.74 compilation errors and adds missing header file for deque to fix compilation error.

Original fix for boost 1.73/boost 1.74 compilation errors is commit at [here](https://github.com/RavenProject/Ravencoin/pull/816).

Adding deque header file fixes #30 